### PR TITLE
Added Support For CommerceIndicator in Auth Requests

### DIFF
--- a/lib/Business/CyberSource/Request/Authorization.pm
+++ b/lib/Business/CyberSource/Request/Authorization.pm
@@ -14,9 +14,20 @@ with qw(
 	Business::CyberSource::Request::Role::TaxService
 );
 
-use MooseX::Types::CyberSource qw( BusinessRules );
+use MooseX::Types::CyberSource qw( BusinessRules AuthService );
 
-has '+service' => ( remote_name => 'ccAuthService' );
+use Module::Runtime qw( use_module );
+
+has '+service' => (
+    remote_name => 'ccAuthService',
+    isa         => AuthService,
+    lazy_build  => 0,
+);
+
+sub _build_service {
+	use_module('Business::CyberSource::RequestPart::Service::Auth');
+	return Business::CyberSource::RequestPart::Service::Auth->new;
+}
 
 has business_rules => (
 	isa         => BusinessRules,

--- a/lib/Business/CyberSource/RequestPart/Service/Auth.pm
+++ b/lib/Business/CyberSource/RequestPart/Service/Auth.pm
@@ -1,0 +1,30 @@
+package Business::CyberSource::RequestPart::Service::Auth;
+use strict;
+use warnings;
+use namespace::autoclean;
+
+# VERSION
+
+use Moose;
+extends 'Business::CyberSource::RequestPart::Service';
+
+use MooseX::Types::CyberSource qw( CommerceIndicator );
+
+has commerce_indicator => (
+	isa         => CommerceIndicator,
+	remote_name => 'commerceIndicator',
+	predicate   => 'has_commerce_indicator',
+	is          => 'rw',
+);
+
+__PACKAGE__->meta->make_immutable;
+1;
+
+# ABSTRACT: Auth
+
+=attr commerce_indicator
+
+The L<commerce_indicator|Business::CyberSource::Response/"commerce_indicator">
+for the authorization that you are performing.
+
+=cut

--- a/lib/MooseX/Types/CyberSource.pm
+++ b/lib/MooseX/Types/CyberSource.pm
@@ -16,12 +16,14 @@ use MooseX::Types -declare => [ qw(
 	DCCIndicator
 
 	Decision
+    CommerceIndicator
 	Items
 
 	Item
 	Card
 	PurchaseTotals
 	Service
+    AuthService
 	AuthReversalService
 	CaptureService
 	CreditService
@@ -65,6 +67,26 @@ my $varchar_message = 'string is empty or longer than ';
 
 enum Decision, [ qw( ACCEPT REJECT ERROR REVIEW ) ];
 
+enum CommerceIndicator, [ qw(
+    aesk
+    aesk_attempted
+    install
+    install_internet
+    internet
+    js
+    js_attempted
+    moto
+    moto_cc
+    recurring
+    recurring_internet
+    retail
+    spa
+    spa_failure
+    vbv
+    vbv_attempted
+    vbv_failure
+) ];
+
 # can't find a standard on this, so I assume these are a cybersource thing
 enum CardTypeCode, [ qw(
 	001
@@ -107,6 +129,7 @@ my $svc = $req . 'Service';
 my $cdc = $req . 'Card';
 my $btc = $req . 'BillTo';
 my $brc = $req . 'BusinessRules';
+my $azs = $req . 'Service::Auth';
 my $ars = $req . 'Service::AuthReversal';
 my $cps = $req . 'Service::Capture';
 my $cds = $req . 'Service::Credit';
@@ -127,6 +150,7 @@ class_type Service,             { class => $svc };
 class_type Card,                { class => $cdc };
 class_type BillTo,              { class => $btc };
 class_type BusinessRules,       { class => $brc };
+class_type AuthService,         { class => $azs };
 class_type AuthReversalService, { class => $ars };
 class_type CaptureService,      { class => $cps };
 class_type CreditService,       { class => $cds };
@@ -144,6 +168,7 @@ class_type Client,              { class => $client   };
 coerce Item,                from HashRef, via { use_module( $itc      )->new( $_ ) };
 coerce PurchaseTotals,      from HashRef, via { use_module( $ptc      )->new( $_ ) };
 coerce Service,             from HashRef, via { use_module( $svc      )->new( $_ ) };
+coerce AuthService,         from HashRef, via { use_module( $azs      )->new( $_ ) };
 coerce AuthReversalService, from HashRef, via { use_module( $ars      )->new( $_ ) };
 coerce CaptureService,      from HashRef, via { use_module( $cps      )->new( $_ ) };
 coerce CreditService,       from HashRef, via { use_module( $cds      )->new( $_ ) };
@@ -319,6 +344,12 @@ Base Type: C<enum>
 
 Numeric codes that specify Card types. Codes denoted with an asterisk* are
 automatically detected when using
+
+=item * C<CommerceIndicator>
+
+Base Type: C<enum>
+
+Valid strings for for use in in the commerceIndicator field.
 
 =item * C<CvResults>
 

--- a/xt/author/authorization/accept.t
+++ b/xt/author/authorization/accept.t
@@ -23,10 +23,16 @@ subtest "American Express" => sub {
     test_successful_authorization({
         card_type => 'amex',
     });
+    test_commerce_indicator({
+        card_type => 'amex',
+    });
 };
 
 subtest "Visa" => sub {
     test_successful_authorization({
+        card_type => 'visa',
+    });
+    test_commerce_indicator({
         card_type => 'visa',
     });
 };
@@ -35,16 +41,45 @@ subtest "MasterCard" => sub {
     test_successful_authorization({
         card_type => 'mastercard',
     });
+    test_commerce_indicator({
+        card_type => 'mastercard',
+    });
 };
 
 subtest "Discover" => sub {
     test_successful_authorization({
         card_type => 'discover',
     });
+    test_commerce_indicator({
+        card_type => 'discover',
+    });
 };
 
 
 done_testing;
+
+sub test_commerce_indicator {
+    state $check = compile( HashRef[Str] );
+    my ( $args ) = $check->( @_ );
+
+    my $card_type = $args->{card_type};
+
+    my $auth_req = $t->resolve(
+        service    => '/request/authorization',
+        parameters => {
+            card =>
+              $t->resolve( service => '/helper/card_' . $args->{card_type} ),
+        }
+    );
+
+    $auth_req->service->commerce_indicator('recurring');
+
+    ok( $client->submit($auth_req)->is_accept,
+        "commerce_indicator 'recurring' accepted for card_type => $card_type"
+    );
+
+    return;
+}
 
 sub test_successful_authorization {
     state $check = compile( HashRef[Str] );


### PR DESCRIPTION
Introduced new enum type: CommerceIndicator based on CyberSource documentation.

Added Business::CyberSource::RequestPart::Service::Auth class so that
commerceIndicator can be submitted to CyberSource for Auth requests. Named the
commerceIndicator attribute 'commerce_indicator' in keeping with the project's
naming conventions.

Updated Business::CyberSource::Request::Authorization to build a
Business::CyberSource::RequestPart::Service::Auth instance for its 'service'
attribute instead of inheriting from its superclass.

Added test for commerce_indicator being sent to CyberSource for Auth requests.