### PR TITLE
Show correct home repository on metacpan

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -23,6 +23,7 @@ copyright_holder = Caleb Cushing <xenoterracide@gmail.com>
 	-bundle = @Author::XENO
 	-remove = AutoPrereqs
 	-remove = Clean
+	-remove = AutoMetaResources
 
 [AutoPrereqs]
 	skip = ^Bread::Board
@@ -78,6 +79,11 @@ copyright_holder = Caleb Cushing <xenoterracide@gmail.com>
 	stopwords = HostGator
 	stopwords = faultstring
 	stopwords = faultcode
+
+[AutoMetaResources]
+	homepage          = https://metacpan.org/dist/%{dist}
+	bugtracker.github = user:hostgator
+	repository.github = user:hostgator
 
 [@Git]
 	tag_format  = %v


### PR DESCRIPTION
Show the up-to-date repo, now maintained by hostgator.

Signed-off-by: Douglas Schrag dschrag@hostgator.com
